### PR TITLE
Issue/3 fr source registry | Source Registry v1

### DIFF
--- a/src/app/api/v1/__init__.py
+++ b/src/app/api/v1/__init__.py
@@ -5,6 +5,7 @@ from .health import router as health_router
 from .login import router as login_router
 from .logout import router as logout_router
 from .runs import router as runs_router
+from .sources import router as sources_router
 from .tasks import router as tasks_router
 from .users import router as users_router
 from .workflows import router as workflows_router
@@ -18,3 +19,4 @@ router.include_router(tasks_router)
 router.include_router(datasets_router)
 router.include_router(workflows_router)
 router.include_router(runs_router)
+router.include_router(sources_router)

--- a/src/app/api/v1/runs.py
+++ b/src/app/api/v1/runs.py
@@ -68,7 +68,7 @@ async def create_run(
     db: Annotated[AsyncSession, Depends(async_get_db)],
 ) -> dict[str, Any]:
     """Create a new run record.
-    
+
     Args:
         request: FastAPI request object
         run_data: Run data

--- a/src/app/api/v1/sources.py
+++ b/src/app/api/v1/sources.py
@@ -8,12 +8,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ...api.dependencies import get_current_user
 from ...core.db.database import async_get_db
-from ...core.exceptions.http_exceptions import BadRequestException, NotFoundException
+from ...core.exceptions.http_exceptions import NotFoundException
 from ...core.registry.service import source_registry_service
 from ...crud.crud_source_registry import crud_source_registry
-from ...models.registry import SourceRegistry
-from ...schemas.registry import SourceRegistryRead, SourceRegistryCreate, SourceRegistryUpdate
-
+from ...schemas.registry import SourceRegistryCreate, SourceRegistryRead, SourceRegistryUpdate
 
 router = APIRouter(prefix="/sources", tags=["sources"])
 
@@ -35,7 +33,7 @@ async def list_sources(
         enabled: Filter by enabled status (True/False)
         page: Page number (1-indexed)
         items_per_page: Number of items per page
-    
+
     Returns:
         Paginated list of sources
     """
@@ -178,7 +176,8 @@ async def delete_source(
     if not source:
         raise NotFoundException(f"Source with id {source_id} not found")
 
-    # not sure how this will be handled yet, whether we delete run records, or prevent deleting a source if there are runs...
+    # not sure how this will be handled yet, whether we delete run records,
+    # or prevent deleting a source if there are runs...
     # from ...crud.crud_run_record import crud_run_records
     # runs = await crud_run_records.get_multi(
     #     db=db,

--- a/src/app/api/v1/sources.py
+++ b/src/app/api/v1/sources.py
@@ -37,6 +37,8 @@ async def list_sources(
         db=db,
         offset=compute_offset(page, items_per_page),
         limit=items_per_page,
+        schema_to_select=SourceRegistryRead,
+        return_total_count=True,
         **filters,
     )
 
@@ -123,3 +125,6 @@ async def delete_source(
     await crud_source_registry.delete(db=db, uuid=source_id)
     
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+# /sources/bulk-add and /sources/bulk-delete and /sources/bulk-update
+# will be useful for lots of sources at once

--- a/src/app/api/v1/sources.py
+++ b/src/app/api/v1/sources.py
@@ -60,9 +60,28 @@ async def register_source(
     return source
 
 @router.get("/{source_id}")
-async def get_source(source_id):
-    pass
+async def get_source(
+    request: Request,
+    source_id: UUID,
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+) -> dict[str, Any]:
+    source = await source_registry_service.get_source(
+        db=db,
+        source_id=source_id,
+    )
+    return source
 
 @router.patch("/{source_id}")
-async def update_source(source_id):
-    pass
+async def update_source(
+    request: Request,
+    source_id: UUID,
+    source_data: SourceRegistryUpdate,
+    current_user: Annotated[dict, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(async_get_db)],
+) -> dict[str, Any]:
+    source = await source_registry_service.update_source(
+        db=db,
+        source_id=source_id,
+        enabled=source_data.enabled,
+    )
+    return source

--- a/src/app/api/v1/sources.py
+++ b/src/app/api/v1/sources.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/sources", tags=["sources"])
+
+@router.get("")
+async def list_sources():
+    pass
+
+@router.post("")
+async def register_source():
+    pass
+
+@router.get("/{source_id}")
+async def get_source(source_id):
+    pass
+
+@router.patch("/{source_id}")
+async def update_source(source_id):
+    pass

--- a/src/app/core/ledger/service.py
+++ b/src/app/core/ledger/service.py
@@ -16,6 +16,7 @@ from ...models.ledger import RunRecord, RunStatus
 from ...schemas.ledger import RunRecordCreateInternal, RunRecordRead
 from ..config import settings
 from ..exceptions.http_exceptions import BadRequestException, NotFoundException
+# from ..registry.service import source_registry_service
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +81,19 @@ class RunLedgerService:
 
         Returns:
             RunRecord (existing or newly created)
+
+        Raises:
+            BadRequestException: If source is not registered in the source registry
         """
+        # registered_source = await source_registry_service.check_existing_source(
+        #     db, project_module, source_identifier
+        # )
+        # if not registered_source:
+        #     raise BadRequestException(
+        #         f"Source {source_identifier} is not registered for project {project_module}. "
+        #         "register the source first before creating a run."
+        #     )
+
         # Check for existing
         existing = await RunLedgerService.check_existing_run(
             db, project_module, source_identifier, dataset_id

--- a/src/app/core/ledger/service.py
+++ b/src/app/core/ledger/service.py
@@ -16,7 +16,7 @@ from ...models.ledger import RunRecord, RunStatus
 from ...schemas.ledger import RunRecordCreateInternal, RunRecordRead
 from ..config import settings
 from ..exceptions.http_exceptions import BadRequestException, NotFoundException
-# from ..registry.service import source_registry_service
+from ..registry.service import source_registry_service
 
 logger = logging.getLogger(__name__)
 
@@ -83,16 +83,22 @@ class RunLedgerService:
             RunRecord (existing or newly created)
 
         Raises:
-            BadRequestException: If source is not registered in the source registry
+            BadRequestException: If source is not registered in the source registry or is disabled
         """
-        # registered_source = await source_registry_service.check_existing_source(
-        #     db, project_module, source_identifier
-        # )
-        # if not registered_source:
-        #     raise BadRequestException(
-        #         f"Source {source_identifier} is not registered for project {project_module}. "
-        #         "register the source first before creating a run."
-        #     )
+        # Validate source is registered and enabled
+        registered_source = await source_registry_service.check_existing_source(
+            db, project_module, source_identifier
+        )
+        if not registered_source:
+            raise BadRequestException(
+                f"Source {source_identifier} is not registered for project {project_module}. "
+                "Register the source first before creating a run."
+            )
+        if not registered_source.get("enabled", False):
+            raise BadRequestException(
+                f"Source {source_identifier} is registered but disabled for project {project_module}. "
+                "Enable the source first before creating a run."
+            )
 
         # Check for existing
         existing = await RunLedgerService.check_existing_run(

--- a/src/app/core/registry/__init__.py
+++ b/src/app/core/registry/__init__.py
@@ -1,0 +1,12 @@
+"""Source registry module.
+"""
+
+from ...models.registry import SourceRegistry
+from .service import SourceRegistryService, source_registry_service
+
+__all__ = [
+    "SourceRegistry",
+    "SourceRegistryService",
+    "source_registry_service",
+]
+

--- a/src/app/core/registry/models.py
+++ b/src/app/core/registry/models.py
@@ -1,0 +1,3 @@
+from ...models.registry import SourceRegistry
+
+__all__ = ["SourceRegistry"]

--- a/src/app/core/registry/service.py
+++ b/src/app/core/registry/service.py
@@ -25,7 +25,17 @@ class SourceRegistryService:
         source_identifier: str,
     ) -> SourceRegistry | None:
         """Check if a source already exists for the given key."""
-        pass
+        try:
+            source = await crud_source_registry.get(
+                db=db,
+                project_module=project_module,
+                source_identifier=source_identifier,
+                schema_to_select=SourceRegistryRead,
+            )
+            return source
+        except Exception as e:
+            logger.exception(f"Error checking existing source for {project_module}/{source_identifier}: {e}")
+            return None
 
     @staticmethod
     async def register_source(

--- a/src/app/core/registry/service.py
+++ b/src/app/core/registry/service.py
@@ -81,34 +81,6 @@ class SourceRegistryService:
         return source
 
     @staticmethod
-    async def list_sources(
-        db: AsyncSession,
-        project_module: str | None = None,
-        enabled: bool | None = None,
-        offset: int = 0,
-        limit: int = 10,
-    ) -> dict[str, Any]:
-        """List sources with filtering and pagination."""
-        filters = {}
-        if project_module is not None:
-            filters["project_module"] = project_module
-        if enabled is not None:
-            filters["enabled"] = enabled
-
-        sources = await crud_source_registry.get_multi(
-            db=db,
-            offset=offset,
-            limit=limit,
-            **filters,
-            schema_to_select=SourceRegistryRead,
-        )
-        return {
-            "items": sources,
-            "offset": offset,
-            "limit": limit,
-        }
-
-    @staticmethod
     async def update_source(
         db: AsyncSession,
         source_id: UUID,

--- a/src/app/core/registry/service.py
+++ b/src/app/core/registry/service.py
@@ -87,7 +87,15 @@ class SourceRegistryService:
         enabled: bool | None = None,
     ) -> SourceRegistry:
         """Update source metadata."""
-        pass
+        source = await crud_source_registry.get(
+            db=db,
+            uuid=source_id,
+            schema_to_select=SourceRegistryRead,
+        )
+        if not source:
+            raise NotFoundException(f"Source with id {source_id} not found")
+        source.enabled = enabled
+        return source
 
     @staticmethod
     async def get_enabled_sources(

--- a/src/app/core/registry/service.py
+++ b/src/app/core/registry/service.py
@@ -144,17 +144,17 @@ class SourceRegistryService:
         )
         if not source:
             raise NotFoundException(f"Source with id {source_id} not found")
-        
+
         update_data: dict[str, Any] = {"updated_at": datetime.now(UTC)}
         if enabled is not None:
             update_data["enabled"] = enabled
-        
+
         await crud_source_registry.update(
             db=db,
             object=update_data,
             uuid=source_id,
         )
-        
+
         updated_source = await crud_source_registry.get(
             db=db,
             uuid=source_id,
@@ -181,7 +181,7 @@ class SourceRegistryService:
         filters: dict[str, Any] = {"enabled": True}
         if project_module:
             filters["project_module"] = project_module
-        
+
         sources_data = await crud_source_registry.get_multi(
             db=db,
             schema_to_select=SourceRegistryRead,

--- a/src/app/core/registry/service.py
+++ b/src/app/core/registry/service.py
@@ -4,13 +4,12 @@ Provides source registration and cataloging functionality.
 """
 import logging
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ...crud.crud_source_registry import crud_source_registry
-from ...models.registry import SourceRegistry
 from ...schemas.registry import SourceRegistryCreateInternal, SourceRegistryRead
 from ..exceptions.http_exceptions import NotFoundException
 
@@ -23,7 +22,7 @@ class SourceRegistryService:
         db: AsyncSession,
         project_module: str,
         source_identifier: str,
-    ) -> SourceRegistry | None:
+    ) -> dict[str, Any] | None:
         """Check if a source already exists for the given key.
 
         Args:
@@ -52,7 +51,7 @@ class SourceRegistryService:
         project_module: str,
         source_identifier: str,
         enabled: bool = False,
-    ) -> SourceRegistry:
+    ) -> dict[str, Any]:
         """Register a new source or return existing (idempotent).
 
         If a source with the same project_module and source_identifier
@@ -93,7 +92,7 @@ class SourceRegistryService:
     async def get_source(
         db: AsyncSession,
         source_id: UUID,
-    ) -> SourceRegistry:
+    ) -> dict[str, Any]:
         """Get a single source by UUID.
 
         Args:
@@ -120,7 +119,7 @@ class SourceRegistryService:
         db: AsyncSession,
         source_id: UUID,
         enabled: bool | None = None,
-    ) -> SourceRegistry:
+    ) -> dict[str, Any]:
         """Update source metadata.
 
         Currently supports updating the enabled status. Updates the
@@ -187,7 +186,7 @@ class SourceRegistryService:
             schema_to_select=SourceRegistryRead,
             **filters,
         )
-        return sources_data.get("items", [])
+        return cast(list[dict[str, Any]], sources_data.get("items", []))
 
 
 # instance

--- a/src/app/core/registry/service.py
+++ b/src/app/core/registry/service.py
@@ -1,0 +1,78 @@
+"""Source registry service.
+
+Provides source registration and cataloging functionality.
+"""
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ...crud.crud_source_registry import crud_source_registry
+from ...models.registry import SourceRegistry
+from ...schemas.registry import SourceRegistryCreateInternal, SourceRegistryRead
+from ..exceptions.http_exceptions import NotFoundException
+
+logger = logging.getLogger(__name__)
+
+
+class SourceRegistryService:
+    @staticmethod
+    async def check_existing_source(
+        db: AsyncSession,
+        project_module: str,
+        source_identifier: str,
+    ) -> SourceRegistry | None:
+        """Check if a source already exists for the given key."""
+        pass
+
+    @staticmethod
+    async def register_source(
+        db: AsyncSession,
+        project_module: str,
+        source_identifier: str,
+        enabled: bool = False,
+    ) -> SourceRegistry:
+        """Register a new source or return existing (idempotent)."""
+        pass
+
+    @staticmethod
+    async def get_source(
+        db: AsyncSession,
+        source_id: UUID,
+    ) -> SourceRegistry:
+        """Get a single source by UUID."""
+        pass
+
+    @staticmethod
+    async def list_sources(
+        db: AsyncSession,
+        project_module: str | None = None,
+        enabled: bool | None = None,
+        offset: int = 0,
+        limit: int = 10,
+    ) -> dict[str, Any]:
+        """List sources with filtering and pagination."""
+        pass
+
+    @staticmethod
+    async def update_source(
+        db: AsyncSession,
+        source_id: UUID,
+        enabled: bool | None = None,
+    ) -> SourceRegistry:
+        """Update source metadata."""
+        pass
+
+    @staticmethod
+    async def get_enabled_sources(
+        db: AsyncSession,
+        project_module: str | None = None,
+    ) -> list[SourceRegistry]:
+        """Get all enabled sources, optionally filtered by project module."""
+        pass
+
+
+# instance
+source_registry_service = SourceRegistryService()

--- a/src/app/core/setup.py
+++ b/src/app/core/setup.py
@@ -207,6 +207,10 @@ def create_application(
 
     application = FastAPI(lifespan=lifespan, **kwargs)
     application.include_router(router)
+    
+    # test
+    from ..views import router as views_router
+    application.include_router(views_router)
 
     if isinstance(settings, ClientSideCacheSettings):
         application.add_middleware(ClientCacheMiddleware, max_age=settings.CLIENT_CACHE_MAX_AGE)

--- a/src/app/crud/crud_source_registry.py
+++ b/src/app/crud/crud_source_registry.py
@@ -1,0 +1,21 @@
+from fastcrud import FastCRUD
+
+from ..models.registry import SourceRegistry
+from ..schemas.registry import (
+    SourceRegistryCreateInternal,
+    SourceRegistryDelete,
+    SourceRegistryRead,
+    SourceRegistryUpdate,
+    SourceRegistryUpdateInternal,
+)
+
+CRUDSourceRegistry = FastCRUD[
+    SourceRegistry,
+    SourceRegistryCreateInternal,
+    SourceRegistryDelete,
+    SourceRegistryUpdate,
+    SourceRegistryUpdateInternal,
+    SourceRegistryRead,
+]
+crud_source_registry = CRUDSourceRegistry(SourceRegistry)
+

--- a/src/app/models/__init__.py
+++ b/src/app/models/__init__.py
@@ -1,2 +1,3 @@
 from .ledger import RunRecord
+from .registry import SourceRegistry
 from .user import User

--- a/src/app/models/registry.py
+++ b/src/app/models/registry.py
@@ -1,0 +1,39 @@
+import uuid as uuid_pkg
+from datetime import UTC, datetime
+
+from sqlalchemy import Boolean, DateTime, Index, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from uuid6 import uuid7
+
+from ..core.db.database import Base
+
+
+class SourceRegistry(Base):
+    __tablename__ = "source_registry"
+
+    # Required
+    project_module: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    source_identifier: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+
+    # default
+    enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default_factory=lambda: datetime.now(UTC), nullable=False
+    )
+
+    # Optional
+    updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, default=None)
+
+    uuid: Mapped[uuid_pkg.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default_factory=uuid7, unique=True, init=False
+    )
+
+    # unique constraint
+    __table_args__ = (
+        UniqueConstraint(
+            "project_module", "source_identifier", name="uq_source_registry_composite"
+        ),
+        Index("idx_source_registry_enabled", "enabled"),
+    )
+

--- a/src/app/schemas/registry.py
+++ b/src/app/schemas/registry.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from typing import Annotated
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..core.schemas import TimestampSchema, UUIDSchema
+
+class SourceRegistryBase(BaseModel):
+    project_module: Annotated[
+        str, Field(min_length=1, max_length=50, examples=["wallaby"], description="Project module identifier")
+    ]
+    source_identifier: Annotated[
+        str,
+        Field(
+            min_length=1,
+            max_length=100,
+            examples=["HIPASSJ1303+07"],
+            description="Source identifier",
+        ),
+    ]
+
+
+class SourceRegistryCreate(SourceRegistryBase):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(default=False, description="monitoring is enabled for this source?")
+
+
+class SourceRegistryCreateInternal(SourceRegistryCreate):
+    pass
+
+
+class SourceRegistryRead(TimestampSchema, SourceRegistryBase, UUIDSchema):
+    model_config = ConfigDict(from_attributes=True)
+
+    enabled: bool
+
+
+class SourceRegistryUpdate(BaseModel):
+    """Schema for updating source registry entries via API."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool | None = Field(default=None, description="monitoring is enabled for this source?")
+
+
+class SourceRegistryUpdateInternal(SourceRegistryUpdate):
+    updated_at: datetime
+
+
+class SourceRegistryDelete(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    is_deleted: bool = Field(default=True, description="Soft delete flag for the source registry entry")
+    deleted_at: datetime | None = Field(default=None, description="Timestamp when the record was deleted")
+

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -16,7 +16,7 @@ async def view_sources(request: Request) -> HTMLResponse:
 </head>
 <body>
     <h1>Source Registry</h1>
-    
+
     <div id="loginSection" style="margin-bottom: 20px; padding: 10px; border: 1px solid #ccc;">
         <h3>Authentication</h3>
         <div>
@@ -27,17 +27,17 @@ async def view_sources(request: Request) -> HTMLResponse:
             <span id="authStatus" style="margin-left: 10px;"></span>
         </div>
     </div>
-    
+
     <div id="addSourceSection" style="margin-bottom: 20px; padding: 10px; border: 1px solid #ccc;">
         <h3>Add New Source</h3>
         <div>
             <label>Project Module: <input type="text" id="newProjectModule" placeholder="e.g. wallaby"></label>
-            <label>Source Identifier: <input type="text" id="newSourceIdentifier" placeholder="e.g. HIPASSJ1303+07"></label>
+            <label>Source Identifier: <input type="text" id="newSourceIdentifier" placeholder="HIPASSJ1303+07"></label>
             <label>Enabled: <input type="checkbox" id="newEnabled"></label>
             <button onclick="addSource()">Add Source</button>
         </div>
     </div>
-    
+
     <div>
         <label>Project Module: <input type="text" id="projectModule" placeholder="project-name"></label>
         <label>Enabled Only: <input type="checkbox" id="enabledOnly"></label>
@@ -61,17 +61,17 @@ async def view_sources(request: Request) -> HTMLResponse:
         </tbody>
     </table>
     <div id="pagination" style="margin-top: 10px;"></div>
-    
+
     <script>
         async function loadSources(page = 1) {
             const projectModule = document.getElementById('projectModule').value;
             const enabledOnly = document.getElementById('enabledOnly').checked;
             const itemsPerPage = 100;
-            
+
             document.getElementById('loading').style.display = 'block';
             document.getElementById('error').style.display = 'none';
             document.getElementById('sourcesTable').style.display = 'none';
-            
+
             try {
                 let url = '/api/v1/sources?page=' + page + '&items_per_page=' + itemsPerPage;
                 if (projectModule) {
@@ -80,17 +80,17 @@ async def view_sources(request: Request) -> HTMLResponse:
                 if (enabledOnly) {
                     url += '&enabled=true';
                 }
-                
+
                 const response = await fetch(url);
                 if (!response.ok) {
                     throw new Error('Failed to load sources: ' + response.statusText);
                 }
-                
+
                 const data = await response.json();
-                
+
                 const tbody = document.getElementById('sourcesBody');
                 tbody.innerHTML = '';
-                
+
                 if (data.data && data.data.length > 0) {
                     data.data.forEach(source => {
                         const row = tbody.insertRow();
@@ -101,22 +101,22 @@ async def view_sources(request: Request) -> HTMLResponse:
                         enabledCell.textContent = source.enabled ? 'Yes' : 'No';
                         row.insertCell(4).textContent = source.created_at || 'N/A';
                         row.insertCell(5).textContent = source.updated_at || 'N/A';
-                        
+
                         const actionsCell = row.insertCell(6);
                         const toggleBtn = document.createElement('button');
                         toggleBtn.textContent = source.enabled ? 'Disable' : 'Enable';
                         toggleBtn.onclick = () => toggleSource(source.uuid, !source.enabled);
                         actionsCell.appendChild(toggleBtn);
-                        
+
                         const deleteBtn = document.createElement('button');
                         deleteBtn.textContent = 'Delete';
                         deleteBtn.onclick = () => deleteSource(source.uuid);
                         deleteBtn.style.marginLeft = '5px';
                         actionsCell.appendChild(deleteBtn);
                     });
-                    
+
                     document.getElementById('sourcesTable').style.display = 'table';
-   
+
                     const paginationDiv = document.getElementById('pagination');
                     paginationDiv.innerHTML = '';
                     if (data.total_pages > 1) {
@@ -126,7 +126,8 @@ async def view_sources(request: Request) -> HTMLResponse:
                             prevBtn.onclick = () => loadSources(data.page - 1);
                             paginationDiv.appendChild(prevBtn);
                         }
-                        paginationDiv.appendChild(document.createTextNode(' Page ' + data.page + ' of ' + data.total_pages + ' '));
+                        const pageText = ' Page ' + data.page + ' of ' + data.total_pages + ' ';
+                        paginationDiv.appendChild(document.createTextNode(pageText));
                         if (data.page < data.total_pages) {
                             const nextBtn = document.createElement('button');
                             nextBtn.textContent = 'Next';
@@ -149,7 +150,7 @@ async def view_sources(request: Request) -> HTMLResponse:
         function getAuthToken() {
             return localStorage.getItem('access_token');
         }
-        
+
         function setAuthToken(token) {
             if (token) {
                 localStorage.setItem('access_token', token);
@@ -161,21 +162,21 @@ async def view_sources(request: Request) -> HTMLResponse:
                 document.getElementById('authStatus').style.color = 'red';
             }
         }
-        
+
         async function login() {
             const username = document.getElementById('username').value;
             const password = document.getElementById('password').value;
-            
+
             if (!username || !password) {
                 alert('Please enter username and password');
                 return;
             }
-            
+
             try {
                 const formData = new URLSearchParams();
                 formData.append('username', username);
                 formData.append('password', password);
-                
+
                 const response = await fetch('/api/v1/login', {
                     method: 'POST',
                     headers: {
@@ -183,12 +184,12 @@ async def view_sources(request: Request) -> HTMLResponse:
                     },
                     body: formData
                 });
-                
+
                 if (!response.ok) {
                     const error = await response.json();
                     throw new Error(error.detail || 'Login failed');
                 }
-                
+
                 const data = await response.json();
                 setAuthToken(data.access_token);
                 document.getElementById('username').value = '';
@@ -197,27 +198,27 @@ async def view_sources(request: Request) -> HTMLResponse:
                 alert('Login error: ' + error.message);
             }
         }
-        
+
         function logout() {
             setAuthToken(null);
         }
-        
+
         async function addSource() {
             const token = getAuthToken();
             if (!token) {
                 alert('Please login first');
                 return;
             }
-            
+
             const projectModule = document.getElementById('newProjectModule').value;
             const sourceIdentifier = document.getElementById('newSourceIdentifier').value;
             const enabled = document.getElementById('newEnabled').checked;
-            
+
             if (!projectModule || !sourceIdentifier) {
                 alert('Please enter project module and source identifier');
                 return;
             }
-            
+
             try {
                 const response = await fetch('/api/v1/sources', {
                     method: 'POST',
@@ -231,12 +232,12 @@ async def view_sources(request: Request) -> HTMLResponse:
                         enabled: enabled
                     })
                 });
-                
+
                 if (!response.ok) {
                     const error = await response.json();
                     throw new Error(error.detail || 'Failed to add source');
                 }
-                
+
                 document.getElementById('newProjectModule').value = '';
                 document.getElementById('newSourceIdentifier').value = '';
                 document.getElementById('newEnabled').checked = false;
@@ -245,18 +246,18 @@ async def view_sources(request: Request) -> HTMLResponse:
                 alert('Error adding source: ' + error.message);
             }
         }
-        
+
         async function toggleSource(sourceId, newEnabled) {
             const token = getAuthToken();
             if (!token) {
                 alert('Please login first');
                 return;
             }
-            
+
             if (!confirm('Are you sure you want to ' + (newEnabled ? 'enable' : 'disable') + ' this source?')) {
                 return;
             }
-            
+
             try {
                 const response = await fetch('/api/v1/sources/' + sourceId, {
                     method: 'PATCH',
@@ -268,29 +269,29 @@ async def view_sources(request: Request) -> HTMLResponse:
                         enabled: newEnabled
                     })
                 });
-                
+
                 if (!response.ok) {
                     const error = await response.json();
                     throw new Error(error.detail || 'Failed to update source');
                 }
-                
+
                 loadSources();
             } catch (error) {
                 alert('Error updating source: ' + error.message);
             }
         }
-        
+
         async function deleteSource(sourceId) {
             const token = getAuthToken();
             if (!token) {
                 alert('Please login first');
                 return;
             }
-            
+
             if (!confirm('Are you sure you want to delete this source? This action cannot be undone.')) {
                 return;
             }
-            
+
             try {
                 const response = await fetch('/api/v1/sources/' + sourceId, {
                     method: 'DELETE',
@@ -298,18 +299,18 @@ async def view_sources(request: Request) -> HTMLResponse:
                         'Authorization': 'Bearer ' + token
                     }
                 });
-                
+
                 if (!response.ok) {
                     const error = await response.text();
                     throw new Error(error || 'Failed to delete source');
                 }
-                
+
                 loadSources();
             } catch (error) {
                 alert('Error deleting source: ' + error.message);
             }
         }
-        
+
         window.onload = function() {
             const token = getAuthToken();
             if (token) {
@@ -324,4 +325,3 @@ async def view_sources(request: Request) -> HTMLResponse:
 </html>
     """
     return HTMLResponse(content=html_content)
-

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -1,0 +1,121 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+
+@router.get("/sources", response_class=HTMLResponse)
+async def view_sources(request: Request) -> HTMLResponse:
+    """testing adding a non API endpoint to the application."""
+    html_content = """
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Source Registry</title>
+    <meta charset="utf-8">
+</head>
+<body>
+    <h1>Source Registry</h1>
+    <div>
+        <label>Project Module: <input type="text" id="projectModule" placeholder="project-name"></label>
+        <label>Enabled Only: <input type="checkbox" id="enabledOnly"></label>
+        <button onclick="loadSources()">Refresh</button>
+    </div>
+    <div id="loading">Loading sources...</div>
+    <div id="error" style="color: red; display: none;"></div>
+    <table id="sourcesTable" border="1" style="border-collapse: collapse; margin-top: 20px; display: none;">
+        <thead>
+            <tr>
+                <th>UUID</th>
+                <th>Project Module</th>
+                <th>Source Identifier</th>
+                <th>Enabled</th>
+                <th>Created At</th>
+                <th>Updated At</th>
+            </tr>
+        </thead>
+        <tbody id="sourcesBody">
+        </tbody>
+    </table>
+    <div id="pagination" style="margin-top: 10px;"></div>
+    
+    <script>
+        async function loadSources(page = 1) {
+            const projectModule = document.getElementById('projectModule').value;
+            const enabledOnly = document.getElementById('enabledOnly').checked;
+            const itemsPerPage = 100;
+            
+            document.getElementById('loading').style.display = 'block';
+            document.getElementById('error').style.display = 'none';
+            document.getElementById('sourcesTable').style.display = 'none';
+            
+            try {
+                let url = '/api/v1/sources?page=' + page + '&items_per_page=' + itemsPerPage;
+                if (projectModule) {
+                    url += '&project_module=' + encodeURIComponent(projectModule);
+                }
+                if (enabledOnly) {
+                    url += '&enabled=true';
+                }
+                
+                const response = await fetch(url);
+                if (!response.ok) {
+                    throw new Error('Failed to load sources: ' + response.statusText);
+                }
+                
+                const data = await response.json();
+                
+                const tbody = document.getElementById('sourcesBody');
+                tbody.innerHTML = '';
+                
+                if (data.data && data.data.length > 0) {
+                    data.data.forEach(source => {
+                        const row = tbody.insertRow();
+                        row.insertCell(0).textContent = source.uuid;
+                        row.insertCell(1).textContent = source.project_module;
+                        row.insertCell(2).textContent = source.source_identifier;
+                        row.insertCell(3).textContent = source.enabled ? 'Yes' : 'No';
+                        row.insertCell(4).textContent = source.created_at || 'N/A';
+                        row.insertCell(5).textContent = source.updated_at || 'N/A';
+                    });
+                    
+                    document.getElementById('sourcesTable').style.display = 'table';
+   
+                    const paginationDiv = document.getElementById('pagination');
+                    paginationDiv.innerHTML = '';
+                    if (data.total_pages > 1) {
+                        if (data.page > 1) {
+                            const prevBtn = document.createElement('button');
+                            prevBtn.textContent = 'Previous';
+                            prevBtn.onclick = () => loadSources(data.page - 1);
+                            paginationDiv.appendChild(prevBtn);
+                        }
+                        paginationDiv.appendChild(document.createTextNode(' Page ' + data.page + ' of ' + data.total_pages + ' '));
+                        if (data.page < data.total_pages) {
+                            const nextBtn = document.createElement('button');
+                            nextBtn.textContent = 'Next';
+                            nextBtn.onclick = () => loadSources(data.page + 1);
+                            paginationDiv.appendChild(nextBtn);
+                        }
+                    }
+                    paginationDiv.appendChild(document.createTextNode(' (Total: ' + data.total + ' sources)'));
+                } else {
+                    document.getElementById('error').textContent = 'No sources found.';
+                    document.getElementById('error').style.display = 'block';
+                }
+            } catch (error) {
+                document.getElementById('error').textContent = 'Error: ' + error.message;
+                document.getElementById('error').style.display = 'block';
+            } finally {
+                document.getElementById('loading').style.display = 'none';
+            }
+        }
+        window.onload = function() {
+            loadSources();
+        };
+    </script>
+</body>
+</html>
+    """
+    return HTMLResponse(content=html_content)
+

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -16,6 +16,28 @@ async def view_sources(request: Request) -> HTMLResponse:
 </head>
 <body>
     <h1>Source Registry</h1>
+    
+    <div id="loginSection" style="margin-bottom: 20px; padding: 10px; border: 1px solid #ccc;">
+        <h3>Authentication</h3>
+        <div>
+            <label>Username: <input type="text" id="username"></label>
+            <label>Password: <input type="password" id="password"></label>
+            <button onclick="login()">Login</button>
+            <button onclick="logout()">Logout</button>
+            <span id="authStatus" style="margin-left: 10px;"></span>
+        </div>
+    </div>
+    
+    <div id="addSourceSection" style="margin-bottom: 20px; padding: 10px; border: 1px solid #ccc;">
+        <h3>Add New Source</h3>
+        <div>
+            <label>Project Module: <input type="text" id="newProjectModule" placeholder="e.g. wallaby"></label>
+            <label>Source Identifier: <input type="text" id="newSourceIdentifier" placeholder="e.g. HIPASSJ1303+07"></label>
+            <label>Enabled: <input type="checkbox" id="newEnabled"></label>
+            <button onclick="addSource()">Add Source</button>
+        </div>
+    </div>
+    
     <div>
         <label>Project Module: <input type="text" id="projectModule" placeholder="project-name"></label>
         <label>Enabled Only: <input type="checkbox" id="enabledOnly"></label>
@@ -32,6 +54,7 @@ async def view_sources(request: Request) -> HTMLResponse:
                 <th>Enabled</th>
                 <th>Created At</th>
                 <th>Updated At</th>
+                <th>Actions</th>
             </tr>
         </thead>
         <tbody id="sourcesBody">
@@ -74,9 +97,22 @@ async def view_sources(request: Request) -> HTMLResponse:
                         row.insertCell(0).textContent = source.uuid;
                         row.insertCell(1).textContent = source.project_module;
                         row.insertCell(2).textContent = source.source_identifier;
-                        row.insertCell(3).textContent = source.enabled ? 'Yes' : 'No';
+                        const enabledCell = row.insertCell(3);
+                        enabledCell.textContent = source.enabled ? 'Yes' : 'No';
                         row.insertCell(4).textContent = source.created_at || 'N/A';
                         row.insertCell(5).textContent = source.updated_at || 'N/A';
+                        
+                        const actionsCell = row.insertCell(6);
+                        const toggleBtn = document.createElement('button');
+                        toggleBtn.textContent = source.enabled ? 'Disable' : 'Enable';
+                        toggleBtn.onclick = () => toggleSource(source.uuid, !source.enabled);
+                        actionsCell.appendChild(toggleBtn);
+                        
+                        const deleteBtn = document.createElement('button');
+                        deleteBtn.textContent = 'Delete';
+                        deleteBtn.onclick = () => deleteSource(source.uuid);
+                        deleteBtn.style.marginLeft = '5px';
+                        actionsCell.appendChild(deleteBtn);
                     });
                     
                     document.getElementById('sourcesTable').style.display = 'table';
@@ -110,7 +146,177 @@ async def view_sources(request: Request) -> HTMLResponse:
                 document.getElementById('loading').style.display = 'none';
             }
         }
+        function getAuthToken() {
+            return localStorage.getItem('access_token');
+        }
+        
+        function setAuthToken(token) {
+            if (token) {
+                localStorage.setItem('access_token', token);
+                document.getElementById('authStatus').textContent = 'Authenticated';
+                document.getElementById('authStatus').style.color = 'green';
+            } else {
+                localStorage.removeItem('access_token');
+                document.getElementById('authStatus').textContent = 'Not authenticated';
+                document.getElementById('authStatus').style.color = 'red';
+            }
+        }
+        
+        async function login() {
+            const username = document.getElementById('username').value;
+            const password = document.getElementById('password').value;
+            
+            if (!username || !password) {
+                alert('Please enter username and password');
+                return;
+            }
+            
+            try {
+                const formData = new URLSearchParams();
+                formData.append('username', username);
+                formData.append('password', password);
+                
+                const response = await fetch('/api/v1/login', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                    body: formData
+                });
+                
+                if (!response.ok) {
+                    const error = await response.json();
+                    throw new Error(error.detail || 'Login failed');
+                }
+                
+                const data = await response.json();
+                setAuthToken(data.access_token);
+                document.getElementById('username').value = '';
+                document.getElementById('password').value = '';
+            } catch (error) {
+                alert('Login error: ' + error.message);
+            }
+        }
+        
+        function logout() {
+            setAuthToken(null);
+        }
+        
+        async function addSource() {
+            const token = getAuthToken();
+            if (!token) {
+                alert('Please login first');
+                return;
+            }
+            
+            const projectModule = document.getElementById('newProjectModule').value;
+            const sourceIdentifier = document.getElementById('newSourceIdentifier').value;
+            const enabled = document.getElementById('newEnabled').checked;
+            
+            if (!projectModule || !sourceIdentifier) {
+                alert('Please enter project module and source identifier');
+                return;
+            }
+            
+            try {
+                const response = await fetch('/api/v1/sources', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer ' + token
+                    },
+                    body: JSON.stringify({
+                        project_module: projectModule,
+                        source_identifier: sourceIdentifier,
+                        enabled: enabled
+                    })
+                });
+                
+                if (!response.ok) {
+                    const error = await response.json();
+                    throw new Error(error.detail || 'Failed to add source');
+                }
+                
+                document.getElementById('newProjectModule').value = '';
+                document.getElementById('newSourceIdentifier').value = '';
+                document.getElementById('newEnabled').checked = false;
+                loadSources();
+            } catch (error) {
+                alert('Error adding source: ' + error.message);
+            }
+        }
+        
+        async function toggleSource(sourceId, newEnabled) {
+            const token = getAuthToken();
+            if (!token) {
+                alert('Please login first');
+                return;
+            }
+            
+            if (!confirm('Are you sure you want to ' + (newEnabled ? 'enable' : 'disable') + ' this source?')) {
+                return;
+            }
+            
+            try {
+                const response = await fetch('/api/v1/sources/' + sourceId, {
+                    method: 'PATCH',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer ' + token
+                    },
+                    body: JSON.stringify({
+                        enabled: newEnabled
+                    })
+                });
+                
+                if (!response.ok) {
+                    const error = await response.json();
+                    throw new Error(error.detail || 'Failed to update source');
+                }
+                
+                loadSources();
+            } catch (error) {
+                alert('Error updating source: ' + error.message);
+            }
+        }
+        
+        async function deleteSource(sourceId) {
+            const token = getAuthToken();
+            if (!token) {
+                alert('Please login first');
+                return;
+            }
+            
+            if (!confirm('Are you sure you want to delete this source? This action cannot be undone.')) {
+                return;
+            }
+            
+            try {
+                const response = await fetch('/api/v1/sources/' + sourceId, {
+                    method: 'DELETE',
+                    headers: {
+                        'Authorization': 'Bearer ' + token
+                    }
+                });
+                
+                if (!response.ok) {
+                    const error = await response.text();
+                    throw new Error(error || 'Failed to delete source');
+                }
+                
+                loadSources();
+            } catch (error) {
+                alert('Error deleting source: ' + error.message);
+            }
+        }
+        
         window.onload = function() {
+            const token = getAuthToken();
+            if (token) {
+                setAuthToken(token);
+            } else {
+                setAuthToken(null);
+            }
             loadSources();
         };
     </script>


### PR DESCRIPTION
This pull request introduces a new "source registry" allowing sources to be registered, listed, updated, and deleted via a new API and associated database model. It also enforces that runs can only be created for registered and enabled sources. The changes are grouped into API additions, model/schema/database changes, and service logic.

**API additions:**

* Added a new `sources` API router with endpoints for listing, registering, retrieving, updating, and deleting sources (`src/app/api/v1/sources.py`)


**Model, schema, and database changes:**

* Introduced the `SourceRegistry` SQLAlchemy model and corresponding Pydantic schemas for API and internal use (`src/app/models/registry.py`, `src/app/schemas/registry.py`).
* Added a new CRUD class for `SourceRegistry` to handle database operations (`src/app/crud/crud_source_registry.py`).

**Service logic and enforcement:**

* Implemented `SourceRegistryService` for managing source registration, retrieval, updating, and enabled source listing (`src/app/core/registry/service.py`, `src/app/core/registry/__init__.py`, `src/app/core/registry/models.py`). 

* Updated the run creation logic to require that the source is registered and enabled before allowing a run to be created (`src/app/core/ledger/service.py`). 

**Other updates:**

* Registered the new model in the global models `__init__.py` for proper imports (`src/app/models/__init__.py`).
* Minor test router inclusion in application setup (`src/app/core/setup.py`).